### PR TITLE
Cache Planttext results using dokuwiki caching capabilities

### DIFF
--- a/syntax/PlantUmlDiagram.php
+++ b/syntax/PlantUmlDiagram.php
@@ -14,6 +14,16 @@ if (!class_exists('PlantUmlDiagram')) {
             return $this->markup;
         }
 
+        /**
+         * Get the SVG code
+         *
+         * @return string
+         */
+        public function getSVG()
+        {
+            return (new DokuHTTPClient())->get($this->getSVGDiagramUrl());
+        }
+
         public function getSVGDiagramUrl() {
             return $this->basePath."svg/".$this->encoded;
         }


### PR DESCRIPTION
Instead of displaying all the time the data directly from planttext use
the handle method to gather the SVG code. The result of handle is cached
internally by dokuwiki, this way the server gather the SVG code, and
serve it.

This modification mean the server need to have access to internet, but
reduce greatly the number of requests done on planttext service.