### PR TITLE
Issue 15 - Fixed issue with UTF-8 Characters

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   plantumlparser
 author Kyle Carter
 email  kylec32@gmail.com
-date   2018-07-03
+date   2018-07-07
 name   PlantUML Parser
 desc   This plugin takes PlantUML markup from a wiki page and has it displayed in a user's browser.
 url    http://www.dokuwiki.org/plugin:plantumlparser

--- a/syntax/PlantUmlDiagram.php
+++ b/syntax/PlantUmlDiagram.php
@@ -37,8 +37,7 @@ if (!class_exists('PlantUmlDiagram')) {
         }
 
         private function encodep($text) {
-            $data = utf8_encode($text);
-            $compressed = gzdeflate($data, 9);
+            $compressed = gzdeflate($text, 9);
             return $this->encode64($compressed);
        }
 

--- a/tests/PlantUmlDiagramTest.php
+++ b/tests/PlantUmlDiagramTest.php
@@ -43,7 +43,7 @@ final class PlantUMLDiagramTest extends TestCase
         $diagramObject = new PlantUmlDiagram("@startuml\nThomas -> Petra : bitte aus Spaß die Türe öffnen\n@enduml");
 
         $this->assertEquals(
-            'https://www.planttext.com/plantuml/png/ut8eBaaiAYdDpU4AoSZFJInMqBLJ24WjAKfKi598oYmfILL8B2rM22v8F3nV8IKpLI7ay9wYL8N3szBIybBpk1nIyr90UW40',
+            'https://www.planttext.com/plantuml/png/SoWkIImgAStDuGh9oCzDB5RGjLC8I2qfIbImKaZAB2b9LKWiBLO8BaWyF5yX9JDL8UJmdg9KXSFRqjBoKlEu75BpKe1w0G00',
             $diagramObject->getPNGDiagramUrl()
         );
     }

--- a/tests/PlantUmlDiagramTest.php
+++ b/tests/PlantUmlDiagramTest.php
@@ -40,7 +40,7 @@ final class PlantUMLDiagramTest extends TestCase
 
     public function testForeignCharacterGeneratedCorrectly()
     {
-        $diagramObject = new PlantUmlDiagram("Thomas -> Petra : bitte aus Spaß die Türe öffnen");
+        $diagramObject = new PlantUmlDiagram("@startuml\nThomas -> Petra : bitte aus Spaß die Türe öffnen\n@enduml");
 
         $this->assertEquals(
             'https://www.planttext.com/plantuml/png/ut8eBaaiAYdDpU4AoSZFJInMqBLJ24WjAKfKi598oYmfILL8B2rM22v8F3nV8IKpLI7ay9wYL8N3szBIybBpk1nIyr90UW40',

--- a/tests/PlantUmlDiagramTest.php
+++ b/tests/PlantUmlDiagramTest.php
@@ -38,6 +38,16 @@ final class PlantUMLDiagramTest extends TestCase
         );
     }
 
+    public function testForeignCharacterGeneratedCorrectly()
+    {
+        $diagramObject = new PlantUmlDiagram("Thomas -> Petra : bitte aus Spaß die Türe öffnen");
+
+        $this->assertEquals(
+            'https://www.planttext.com/plantuml/png/ut8eBaaiAYdDpU4AoSZFJInMqBLJ24WjAKfKi598oYmfILL8B2rM22v8F3nV8IKpLI7ay9wYL8N3szBIybBpk1nIyr90UW40',
+            $diagramObject->getPNGDiagramUrl()
+        );
+    }
+
     public function testGetMarkup()
     {
         $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml");


### PR DESCRIPTION
Because Dokuwiki already has everything in UTF-8 we don't need to convert to UTF-8. Got rid of conversion to UTF-8 as it was messing things up. 