### PR TITLE
Plant UML Server configurable in Dokuwiki

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,3 @@
+<?php
+$conf['PlantUMLURL']="https://www.plantuml.com/plantuml/";
+

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,3 @@
+<?php
+$meta['PlantUMLURL']= array('string');
+

--- a/syntax/PlantUmlDiagram.php
+++ b/syntax/PlantUmlDiagram.php
@@ -3,11 +3,12 @@ if (!class_exists('PlantUmlDiagram')) {
     class PlantUmlDiagram {
         private $markup;
         private $encoded;
-        private $basePath = "https://www.plantuml.com/plantuml/";
+        private $basePath;
 
-        public function __construct($markup) {
+        public function __construct($markup,$plantUmlUrl) {
             $this->markup = nl2br($markup);
             $this->encoded = $this->encodep($markup);
+            $this->basePath = $plantUmlUrl;
         }
 
         public function getMarkup() {

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -41,7 +41,16 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
     public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         $markup        = str_replace('</' . $this->TAG . '>', '', str_replace('<' . $this->TAG . '>', '', $match));
-        $diagramObject = new PlantUmlDiagram($markup);
+        $plantUmlUrl   = trim($this->getConf('PlantUMLURL'));
+		if(!$plantUmlUrl)
+		{
+			$plantUmlUrl = "https://www.plantuml.com/plantuml/";
+		}
+		else
+		{
+			$plantUmlUrl = trim($plantUmlUrl, '/') . '/';
+		}
+        $diagramObject = new PlantUmlDiagram($markup,$plantUmlUrl);
 
         return [
             'svg' => strstr($diagramObject->getSVG(), "<svg"),

--- a/tests/PlantUmlDiagramTest.php
+++ b/tests/PlantUmlDiagramTest.php
@@ -10,7 +10,7 @@ final class PlantUMLDiagramTest extends TestCase
 
     public function testSvgUrlGeneratedCorrectly()
     {
-        $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml");
+        $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml","https://www.plantuml.com/plantuml/");
 
         $this->assertEquals(
             'https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuKhCoKnELT2rKqZAJx9IgCnNACz8B54eBU02ydNjmB9M2ddv9GgvfSaPN0wfUIb0NG00',
@@ -20,7 +20,7 @@ final class PlantUMLDiagramTest extends TestCase
 
     public function testPngUrlGeneratedCorrectly()
     {
-        $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml");
+        $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml","https://www.plantuml.com/plantuml/");
 
         $this->assertEquals(
             'https://www.plantuml.com/plantuml/png/SoWkIImgAStDuKhCoKnELT2rKqZAJx9IgCnNACz8B54eBU02ydNjmB9M2ddv9GgvfSaPN0wfUIb0NG00',
@@ -30,7 +30,7 @@ final class PlantUMLDiagramTest extends TestCase
 
     public function testTxtUrlGeneratedCorrectly()
     {
-        $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml");
+        $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml","https://www.plantuml.com/plantuml/");
 
         $this->assertEquals(
             'https://www.plantuml.com/plantuml/txt/SoWkIImgAStDuKhCoKnELT2rKqZAJx9IgCnNACz8B54eBU02ydNjmB9M2ddv9GgvfSaPN0wfUIb0NG00',
@@ -40,7 +40,7 @@ final class PlantUMLDiagramTest extends TestCase
 
     public function testForeignCharacterGeneratedCorrectly()
     {
-        $diagramObject = new PlantUmlDiagram("@startuml\nThomas -> Petra : bitte aus Spaß die Türe öffnen\n@enduml");
+        $diagramObject = new PlantUmlDiagram("@startuml\nThomas -> Petra : bitte aus Spaß die Türe öffnen\n@enduml","https://www.plantuml.com/plantuml/");
 
         $this->assertEquals(
             'https://www.plantuml.com/plantuml/png/SoWkIImgAStDuGh9oCzDB5RGjLC8I2qfIbImKaZAB2b9LKWiBLO8BaWyF5yX9JDL8UJmdg9KXSFRqjBoKlEu75BpKe1w0G00',
@@ -50,7 +50,7 @@ final class PlantUMLDiagramTest extends TestCase
 
     public function testGetMarkup()
     {
-        $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml");
+        $diagramObject = new PlantUmlDiagram("@startuml\nalice -> bob: yo what up\nbob->alice: not much\n@enduml","https://www.plantuml.com/plantuml/");
 
         $this->assertEquals(
             '@startuml<br />


### PR DESCRIPTION
I update the plugin to enable configuration of the plant uml server URL. With this configuration I was able to link to my local dockerized plantuml server. This could help solving the issue #31.  