### PR TITLE
Add option to hide link section

### DIFF
--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,3 +1,3 @@
 <?php
 $meta['PlantUMLURL']= array('string');
-
+$meta['PlantUMLHideLinkSection']= array('onoff');

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -74,6 +74,7 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
      */
     public function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'xhtml') return false;
+        $plantUMLHideLinkSection = $this->getConf('PlantUMLHideLinkSection');
 
         $renderer->doc .= "<div id='plant-uml-diagram-".$data['id']."'>";
         if(strlen($data['svg']) > 0) {
@@ -88,12 +89,15 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
             $renderer->doc .= "<span>".$data['markup']."</span>";
             $renderer->doc .= "</object>";
         }
-        $renderer->doc .= "<div id=\"plantumlparse_link_section\">";
-        $renderer->doc .= "<a target='_blank' href='".$data['url']['svg']."'>SVG</a> | ";
-        $renderer->doc .= "<a target='_blank' href='".$data['url']['png']."'>PNG</a> | ";
-        $renderer->doc .= "<a target='_blank' href='".$data['url']['txt']."'>TXT</a>";
-        $renderer->doc .= "</div>";
-        $renderer->doc .= "</div>";
+	
+	if ($plantUMLHideLinkSection != 1) {
+		$renderer->doc .= "<div id=\"plantumlparse_link_section\">";
+		$renderer->doc .= "<a target='_blank' href='".$data['url']['svg']."'>SVG</a> | ";
+		$renderer->doc .= "<a target='_blank' href='".$data['url']['png']."'>PNG</a> | ";
+		$renderer->doc .= "<a target='_blank' href='".$data['url']['txt']."'>TXT</a>";
+		$renderer->doc .= "</div>";
+	}
+	$renderer->doc .= "</div>";
 
         return true;
     }


### PR DESCRIPTION
I use my own PlantUML xeb server which is only accessible on localhost and i don't want expose it to the internet. This plugin add links to get diagram in differents formats with the url provided by `PlantUMLURL` config param and if we use PlanUML web server with localhost url this publish localhost url. So i need to hide this links.

This small pull-request add an option to hide theses links if we need to hide them.