### PR TITLE
Fixed LaTeX/Ditaa Parse, Add ODT Export Support and Fix UML Search Result SVG Rendering

### DIFF
--- a/action.php
+++ b/action.php
@@ -1,0 +1,35 @@
+<?php
+if (!defined('DOKU_INC')) die();
+
+class action_plugin_plantumlparser extends DokuWiki_Action_Plugin
+{
+    public function register(Doku_Event_Handler $controller)
+    {
+        $controller->register_hook('TPL_CONTENT_DISPLAY', 'BEFORE', $this, 'componentUMLContent', array());
+    }
+    
+    /**
+    * Fix UML search result in the content
+    * When searching for a string that is inside a ``uml`` tag with SVG rendering, 
+    * the DokuWiki built-in syntax highlighter breaks SVG content when applying highlight into it. 
+    * This function removes the search highlight inside SVG to avoid breaking SVG rendering.
+    */
+    function componentUMLContent(Doku_Event &$event, $param)
+    {
+        $dom = new DomDocument();
+        @$dom->loadHTML(mb_convert_encoding($event->data, 'HTML-ENTITIES', "UTF-8"));
+        $xpath = new DOMXPath($dom);
+        
+        foreach ($xpath->query("//div[starts-with(@id,'plant-uml-diagram')]//span[contains(@class,'search_hit')]") as $node) {
+            // $text->nodeValue = "TESTE";
+            $fragment = $dom->createDocumentFragment();
+            $fragment->appendXML($node->nodeValue);
+    
+            $parent = $node->parentNode;
+            $parent->insertBefore($fragment,$node);
+            $parent->removeChild($node);
+        }
+        
+        $event->data = $dom->saveHTML($dom->documentElement);
+    }
+}

--- a/action.php
+++ b/action.php
@@ -9,7 +9,7 @@ class action_plugin_plantumlparser extends DokuWiki_Action_Plugin
     }
     
     /**
-    * Fix UML search result in the content
+    * Fix UML search result in the content (Issue #30)
     * When searching for a string that is inside a ``uml`` tag with SVG rendering, 
     * the DokuWiki built-in syntax highlighter breaks SVG content when applying highlight into it. 
     * This function removes the search highlight inside SVG to avoid breaking SVG rendering.
@@ -21,7 +21,6 @@ class action_plugin_plantumlparser extends DokuWiki_Action_Plugin
         $xpath = new DOMXPath($dom);
         
         foreach ($xpath->query("//div[starts-with(@id,'plant-uml-diagram')]//span[contains(@class,'search_hit')]") as $node) {
-            // $text->nodeValue = "TESTE";
             $fragment = $dom->createDocumentFragment();
             $fragment->appendXML($node->nodeValue);
     

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -125,13 +125,17 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
     protected function _render_odt(Doku_Renderer $renderer, $state, $txtdata) {
         // if($state === DOKU_LEXER_UNMATCHED) {
 			if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
-				list($width, $height) = $renderer->_odtGetImageSize($txtdata['url']['png']);
-				$renderer->_odtAddImage($txtdata['url']['png'], $width, $height);
+				list($widthPngInCm, $heightPngInCm) = $renderer->_odtGetImageSize($txtdata['url']['png']);
+				$renderer->_odtAddImage($txtdata['url']['png'], $widthPngInCm, $heightPngInCm);
 			} else {
-				list($width, $height) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
+				list($widthSvgInCm, $heightSvgInCm) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
 				// $renderer->unformatted("Width: ".$width."cm");
 				// $renderer->unformatted("Height: ".$height."cm");
-				$renderer->_addStringAsSVGImage($txtdata['svg'], $width, $height);
+				// When exporting to ODT format always make the SVG as wide
+				// as the whole page without margins (but keep the width/height relation!). 
+				$widthInCm = $renderer->_getAbsWidthMindMargins();
+				$heightInCm = $widthInCm * ($heightSvgInCm/$widthSvgInCm);
+				$renderer->_addStringAsSVGImage($txtdata['svg'], $widthInCm, $heightInCm);
 			}
         // }
 

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -126,7 +126,7 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
         // if($state === DOKU_LEXER_UNMATCHED) {
 			if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
 				list($widthPngInCm, $heightPngInCm) = $renderer->_odtGetImageSize($txtdata['url']['png']);
-				$renderer->_odtAddImage($txtdata['url']['png'], $widthPngInCm, $heightPngInCm);
+				$renderer->_odtAddImage($txtdata['url']['png'], $widthPngInCm.'cm', $heightPngInCm.'cm');
 			} else {
 				list($widthSvgInCm, $heightSvgInCm) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
 				// $renderer->unformatted("Width: ".$widthSvgInCm."cm");
@@ -135,7 +135,7 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
 				// as the whole page without margins (but keep the width/height relation!). 
 				$widthInCm = $renderer->_getAbsWidthMindMargins();
 				$heightInCm = $widthInCm * ($heightSvgInCm/$widthSvgInCm);
-				$renderer->_addStringAsSVGImage($txtdata['svg'], $widthInCm, $heightInCm);
+				$renderer->_addStringAsSVGImage($data['markup'], $widthSvgInCm.'cm', $heightSvgInCm.'cm');
 			}
         // }
 

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -126,16 +126,14 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
         // if($state === DOKU_LEXER_UNMATCHED) {
 			if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
 				list($widthPngInCm, $heightPngInCm) = $renderer->_odtGetImageSize($txtdata['url']['png']);
-				$renderer->_odtAddImage($txtdata['url']['png'], $widthPngInCm.'cm', $heightPngInCm.'cm');
+				$renderer->_odtAddImage($txtdata['url']['png'], $widthPngInCm, $heightPngInCm);
 			} else {
 				list($widthSvgInCm, $heightSvgInCm) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
 				// $renderer->unformatted("Width: ".$widthSvgInCm."cm");
 				// $renderer->unformatted("Height: ".$heightSvgInCm."cm");
 				// When exporting to ODT format always make the SVG as wide
 				// as the whole page without margins (but keep the width/height relation!). 
-				$widthInCm = $renderer->_getAbsWidthMindMargins();
-				$heightInCm = $widthInCm * ($heightSvgInCm/$widthSvgInCm);
-				$renderer->_addStringAsSVGImage($data['markup'], $widthSvgInCm.'cm', $heightSvgInCm.'cm');
+				$renderer->_addStringAsSVGImage($data['markup'], $widthSvgInCm, $heightSvgInCm);
 			}
         // }
 

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -124,17 +124,18 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
      */
     protected function _render_odt(Doku_Renderer $renderer, $state, $txtdata) {
         // if($state === DOKU_LEXER_UNMATCHED) {
-			if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
+			// Actually the SVG export from ODT plugin is broken, so we'll export as PNG as a workaround instead	    
+			// if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
 				list($widthPngInCm, $heightPngInCm) = $renderer->_odtGetImageSize($txtdata['url']['png']);
 				$renderer->_odtAddImage($txtdata['url']['png'], $widthPngInCm, $heightPngInCm);
-			} else {
+			/* } else {
 				list($widthSvgInCm, $heightSvgInCm) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
 				// $renderer->unformatted("Width: ".$widthSvgInCm."cm");
 				// $renderer->unformatted("Height: ".$heightSvgInCm."cm");
 				// When exporting to ODT format always make the SVG as wide
 				// as the whole page without margins (but keep the width/height relation!). 
 				$renderer->_addStringAsSVGImage($data['markup'], $widthSvgInCm, $heightSvgInCm);
-			}
+			} */
         // }
 
         return true;

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -125,12 +125,10 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
     protected function _render_odt(Doku_Renderer $renderer, $state, $txtdata) {
         // if($state === DOKU_LEXER_UNMATCHED) {
 			if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
-			    $im = imagecreatefromstring((new DokuHTTPClient())->get($txtdata['url']['png']));
-				$width = imagesx($im);
-				$height = imagesy($im);
+				list($width, $height) = $renderer->_odtGetImageSize($txtdata['url']['png']);
 				$renderer->_odtAddImage($txtdata['url']['png'], $width, $height);
 			} else {
-			    list($width, $height) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
+				list($width, $height) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
 				// $renderer->unformatted("Width: ".$width."cm");
 				// $renderer->unformatted("Height: ".$height."cm");
 				$renderer->_addStringAsSVGImage($txtdata['svg'], $width, $height);

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -129,8 +129,8 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
 				$renderer->_odtAddImage($txtdata['url']['png'], $widthPngInCm, $heightPngInCm);
 			} else {
 				list($widthSvgInCm, $heightSvgInCm) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
-				// $renderer->unformatted("Width: ".$width."cm");
-				// $renderer->unformatted("Height: ".$height."cm");
+				// $renderer->unformatted("Width: ".$widthSvgInCm."cm");
+				// $renderer->unformatted("Height: ".$heightSvgInCm."cm");
 				// When exporting to ODT format always make the SVG as wide
 				// as the whole page without margins (but keep the width/height relation!). 
 				$widthInCm = $renderer->_getAbsWidthMindMargins();

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -130,10 +130,7 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
 				$height = imagesy($im);
 				$renderer->_odtAddImage($txtdata['url']['png'], $width, $height);
 			} else {
-				$dim=$this->_extract_XY_4svg( $txtdata['svg'] );
-				// $renderer->unformatted("Width: ".$dim[0]."px");
-				// $renderer->unformatted("Height: ".$dim[1]."px");
-				list($width, $height) = $this->_odtGetImageSize(NULL, $dim[0], $dim[1]);
+			    list($width, $height) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
 				// $renderer->unformatted("Width: ".$width."cm");
 				// $renderer->unformatted("Height: ".$height."cm");
 				$renderer->_addStringAsSVGImage($txtdata['svg'], $width, $height);
@@ -141,70 +138,5 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
         // }
 
         return true;
-    }
-
-    /**
-     * Find the SVG X and Y dimensions in the svg string of the image.
-     * it searches for 'width="nnnpx" height="mmmpx"' in the first
-     * given string and returns the dimension in inch.
-     *
-     * @param String  $svgtxt  The svg string to inspect
-     * @return array the X and Y dimensions suitable as SVG dimensions
-     */
-    protected function _extract_XY_4svg( $svgtxt ) {
-        // $sizes=array();
-        // preg_match( '/width="(.*?)px" height="(.*?)px"/', $svgtxt, $sizes );
-		// array_shift($sizes);
-
-		$matchesWidth=array();
-		$matchesHeight=array();
-		preg_match( '/<svg.*?width="((\d+))/', $svgtxt, $matchesWidth);
-		preg_match( '/<svg.*?height="((\d+))/', $svgtxt, $matchesHeight);
-		$sizes = array($matchesWidth[1], $matchesHeight[1]);
-
-        // assume a 96 dpi screen
-        // return array_map( function($v) { return ($v/96.0)."in"; }, $sizes );
-
-		return $sizes;
-    }
-
-	protected function _odtGetImageSize($src, $width = NULL, $height = NULL){
-        if (file_exists($src)) {
-            $info  = getimagesize($src);
-            if(!$width){
-                $width  = $info[0];
-                $height = $info[1];
-            }else{
-                $height = round(($width * $info[1]) / $info[0]);
-            }
-        }
-
-        // convert from pixel to centimeters
-        if ($width) $width = (($width/96.0)*2.54);
-        if ($height) $height = (($height/96.0)*2.54);
-
-        if ($width && $height) {
-            // Don't be wider than the page
-            if ($width >= 17){ // FIXME : this assumes A4 page format with 2cm margins
-                $width = $width.'cm"  style:rel-width="100%';
-                $height = $height.'cm"  style:rel-height="scale';
-            } else {
-                $width = $width.'cm';
-                $height = $height.'cm';
-            }
-        } else {
-            // external image and unable to download, fallback
-            if ($width) {
-                $width = $width."cm";
-            } else {
-                $width = '" svg:rel-width="100%';
-            }
-            if ($height) {
-                $height = $height."cm";
-            } else {
-                $height = '" svg:rel-height="100%';
-            }
-        }
-        return array($width, $height);
     }
 }

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -56,6 +56,7 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
             'svg' => strstr($diagramObject->getSVG(), "<svg"),
             'markup' => $diagramObject->getMarkup(),
             'id' => sha1($diagramObject->getSVGDiagramUrl()),
+            'include_links' => $this->getConf('DefaultShowLinks'),
             'url' => [
                 'svg' => $diagramObject->getSVGDiagramUrl(),
                 'png' => $diagramObject->getPNGDiagramUrl(),
@@ -73,28 +74,137 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
      * @return bool If rendering was successful.
      */
     public function render($mode, Doku_Renderer $renderer, $data) {
-        if($mode != 'xhtml') return false;
-
-        $renderer->doc .= "<div id='plant-uml-diagram-".$data['id']."'>";
-        if(strlen($data['svg']) > 0) {
-			if(is_a($renderer,'renderer_plugin_dw2pdf') && (preg_match("/(@startlatex|@startmath|<math|<latex)/", $data['markup']))){
-				$renderer->doc .= "<img src='".$data['url']['png']."'>";
+        switch($mode) {
+        case 'xhtml':
+			$renderer->doc .= "<div id='plant-uml-diagram-".$data['id']."'>";
+            if(strlen($data['svg']) > 0) {
+				if(preg_match("/(@startlatex|@startmath|<math|<latex)/", $data['markup'])){
+					$renderer->doc .= "<img src='".$data['url']['png']."'>";
+				}
+				else {
+					$renderer->doc .= $data['svg'];
+				}
+			} else {
+			    if(preg_match("/(ditaa)/", $data['markup'])){
+					$renderer->doc .= "<img src='".$data['url']['png']."'>";
+				}
+				else {
+				    $renderer->doc .= "<object data='".$data['url']['svg']."' type='image/svg+xml'>";
+				    $renderer->doc .= "<span>".$data['markup']."</span>";
+				    $renderer->doc .= "</object>";
+				}
 			}
-			else {
-				$renderer->doc .= $data['svg'];
-			}
-        } else {
-            $renderer->doc .= "<object data='".$data['url']['svg']."' type='image/svg+xml'>";
-            $renderer->doc .= "<span>".$data['markup']."</span>";
-            $renderer->doc .= "</object>";
+        
+            if($data['include_links'] == "1") {
+                $renderer->doc .= "<div id=\"plantumlparse_link_section\">";
+                $renderer->doc .= "<a target='_blank' href='".$data['url']['svg']."'>SVG</a> | ";
+                $renderer->doc .= "<a target='_blank' href='".$data['url']['png']."'>PNG</a> | ";
+                $renderer->doc .= "<a target='_blank' href='".$data['url']['txt']."'>TXT</a>";
+                $renderer->doc .= "</div>";
+            }
+        
+            $renderer->doc .= "</div>";
+        break;
+        case 'odt': case 'odt_pdf':
+            return $this->_render_odt($renderer, $state, $data);
+        break;
         }
-        $renderer->doc .= "<div id=\"plantumlparse_link_section\">";
-        $renderer->doc .= "<a target='_blank' href='".$data['url']['svg']."'>SVG</a> | ";
-        $renderer->doc .= "<a target='_blank' href='".$data['url']['png']."'>PNG</a> | ";
-        $renderer->doc .= "<a target='_blank' href='".$data['url']['txt']."'>TXT</a>";
-        $renderer->doc .= "</div>";
-        $renderer->doc .= "</div>";
 
         return true;
+    }
+
+    /**
+     * Render odt output.
+     *
+     * @param Doku_Renderer  $renderer  The renderer
+     * @param int            $state     The state
+     * @param string         $txtdata   The data from the render() function
+     * @param string         $align     img align
+     * @return bool If rendering was successful.
+     */
+    protected function _render_odt(Doku_Renderer $renderer, $state, $txtdata) {
+        // if($state === DOKU_LEXER_UNMATCHED) {
+			if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
+			    $im = imagecreatefromstring((new DokuHTTPClient())->get($txtdata['url']['png']));
+				$width = imagesx($im);
+				$height = imagesy($im);
+				$renderer->_odtAddImage($txtdata['url']['png'], $width, $height);
+			} else {
+				$dim=$this->_extract_XY_4svg( $txtdata['svg'] );
+				// $renderer->unformatted("Width: ".$dim[0]."px");
+				// $renderer->unformatted("Height: ".$dim[1]."px");
+				list($width, $height) = $this->_odtGetImageSize(NULL, $dim[0], $dim[1]);
+				// $renderer->unformatted("Width: ".$width."cm");
+				// $renderer->unformatted("Height: ".$height."cm");
+				$renderer->_addStringAsSVGImage($txtdata['svg'], $width, $height);
+			}
+        // }
+
+        return true;
+    }
+
+    /**
+     * Find the SVG X and Y dimensions in the svg string of the image.
+     * it searches for 'width="nnnpx" height="mmmpx"' in the first
+     * given string and returns the dimension in inch.
+     *
+     * @param String  $svgtxt  The svg string to inspect
+     * @return array the X and Y dimensions suitable as SVG dimensions
+     */
+    protected function _extract_XY_4svg( $svgtxt ) {
+        // $sizes=array();
+        // preg_match( '/width="(.*?)px" height="(.*?)px"/', $svgtxt, $sizes );
+		// array_shift($sizes);
+
+		$matchesWidth=array();
+		$matchesHeight=array();
+		preg_match( '/<svg.*?width="((\d+))/', $svgtxt, $matchesWidth);
+		preg_match( '/<svg.*?height="((\d+))/', $svgtxt, $matchesHeight);
+		$sizes = array($matchesWidth[1], $matchesHeight[1]);
+
+        // assume a 96 dpi screen
+        // return array_map( function($v) { return ($v/96.0)."in"; }, $sizes );
+
+		return $sizes;
+    }
+
+	protected function _odtGetImageSize($src, $width = NULL, $height = NULL){
+        if (file_exists($src)) {
+            $info  = getimagesize($src);
+            if(!$width){
+                $width  = $info[0];
+                $height = $info[1];
+            }else{
+                $height = round(($width * $info[1]) / $info[0]);
+            }
+        }
+
+        // convert from pixel to centimeters
+        if ($width) $width = (($width/96.0)*2.54);
+        if ($height) $height = (($height/96.0)*2.54);
+
+        if ($width && $height) {
+            // Don't be wider than the page
+            if ($width >= 17){ // FIXME : this assumes A4 page format with 2cm margins
+                $width = $width.'cm"  style:rel-width="100%';
+                $height = $height.'cm"  style:rel-height="scale';
+            } else {
+                $width = $width.'cm';
+                $height = $height.'cm';
+            }
+        } else {
+            // external image and unable to download, fallback
+            if ($width) {
+                $width = $width."cm";
+            } else {
+                $width = '" svg:rel-width="100%';
+            }
+            if ($height) {
+                $height = $height."cm";
+            } else {
+                $height = '" svg:rel-height="100%';
+            }
+        }
+        return array($width, $height);
     }
 }

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -109,7 +109,7 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
             // if($state === DOKU_LEXER_UNMATCHED) {
     			// Actually the SVG export from ODT plugin is broken, so we'll export as PNG as a workaround instead	    
     			// if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
-    				$renderer->_odtAddImage($txtdata['url']['png']);
+    				$renderer->_odtAddImage($data['url']['png']);
     			/* } else {
     				list($widthSvgInCm, $heightSvgInCm) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
     				// $renderer->unformatted("Width: ".$widthSvgInCm."cm");

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -106,37 +106,21 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
             $renderer->doc .= "</div>";
         break;
         case 'odt': case 'odt_pdf':
-            return $this->_render_odt($renderer, $state, $data);
+            // if($state === DOKU_LEXER_UNMATCHED) {
+    			// Actually the SVG export from ODT plugin is broken, so we'll export as PNG as a workaround instead	    
+    			// if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
+    				$renderer->_odtAddImage($txtdata['url']['png']);
+    			/* } else {
+    				list($widthSvgInCm, $heightSvgInCm) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
+    				// $renderer->unformatted("Width: ".$widthSvgInCm."cm");
+    				// $renderer->unformatted("Height: ".$heightSvgInCm."cm");
+    				// When exporting to ODT format always make the SVG as wide
+    				// as the whole page without margins (but keep the width/height relation!). 
+    				$renderer->_addStringAsSVGImage($data['markup'], $widthSvgInCm, $heightSvgInCm);
+    			} */
+            // }
         break;
         }
-
-        return true;
-    }
-
-    /**
-     * Render odt output.
-     *
-     * @param Doku_Renderer  $renderer  The renderer
-     * @param int            $state     The state
-     * @param string         $txtdata   The data from the render() function
-     * @param string         $align     img align
-     * @return bool If rendering was successful.
-     */
-    protected function _render_odt(Doku_Renderer $renderer, $state, $txtdata) {
-        // if($state === DOKU_LEXER_UNMATCHED) {
-			// Actually the SVG export from ODT plugin is broken, so we'll export as PNG as a workaround instead	    
-			// if(preg_match("/(@startlatex|@startmath|<math|<latex|ditaa)/", $txtdata['markup'])){
-				list($widthPngInCm, $heightPngInCm) = $renderer->_odtGetImageSize($txtdata['url']['png']);
-				$renderer->_odtAddImage($txtdata['url']['png'], $widthPngInCm, $heightPngInCm);
-			/* } else {
-				list($widthSvgInCm, $heightSvgInCm) = $renderer->_odtGetImageSize($txtdata['url']['svg']);
-				// $renderer->unformatted("Width: ".$widthSvgInCm."cm");
-				// $renderer->unformatted("Height: ".$heightSvgInCm."cm");
-				// When exporting to ODT format always make the SVG as wide
-				// as the whole page without margins (but keep the width/height relation!). 
-				$renderer->_addStringAsSVGImage($data['markup'], $widthSvgInCm, $heightSvgInCm);
-			} */
-        // }
 
         return true;
     }


### PR DESCRIPTION
PlantUML apparently doesn't support SVG output for LaTeX and Ditaa, so now the code always use PNG images.
Added support for ODT export.
This commit also fixes UML search result in the content (Issue #30). This is a well known issue, as related in https://bugs.dokuwiki.org/2321.html - When searching for a string that is inside a ``uml`` tag with SVG rendering, the DokuWiki built-in syntax highlighter breaks SVG content when applying highlight into it. This commit removes the search highlight inside SVG to avoid breaking SVG rendering.