### PR TITLE
replaced DokuHTTPClient())->get against php-curl due to timing issues

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   plantumlparser
 author Kyle Carter
 email  kylec32@gmail.com
-date   2021-05-17
+date   2020-04-22
 name   PlantUML Parser
 desc   This plugin takes PlantUML markup from a wiki page and has it displayed in a user's browser.
 url    http://www.dokuwiki.org/plugin:plantumlparser

--- a/syntax/PlantUmlDiagram.php
+++ b/syntax/PlantUmlDiagram.php
@@ -15,6 +15,30 @@ if (!class_exists('PlantUmlDiagram')) {
             return $this->markup;
         }
 
+ /**
+  * call plantuml via curl to cope with non-caching plantuml-server
+  *
+  * @param string       $url    complete url of plantuml-call
+  * @return    response from plantuml-server
+  */
+ public function callCurl($url) {
+        $ch=curl_init();
+        $timeout=5;
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYSTATUS, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        // curl_setopt($ch, CURLOPT_VERBOSE, 1);
+        // curl_setopt($ch, CURLOPT_FAILONERROR, 1);
+        // curl_setopt($ch, CURLOPT_VERBOSE, 1)
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+        // Get URL content
+        $lines_string=curl_exec($ch);
+        // close handle to release resources
+        curl_close($ch);
+        return $lines_string;
+}
+
         /**
          * Get the SVG code
          *
@@ -22,7 +46,8 @@ if (!class_exists('PlantUmlDiagram')) {
          */
         public function getSVG()
         {
-            return (new DokuHTTPClient())->get($this->getSVGDiagramUrl());
+            // return (new DokuHTTPClient())->get($this->getSVGDiagramUrl());
+	    return $this->callCurl($this->getSVGDiagramUrl());	
         }
 
         public function getSVGDiagramUrl() {

--- a/syntax/injector.php
+++ b/syntax/injector.php
@@ -54,6 +54,7 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
 
         return [
             'svg' => strstr($diagramObject->getSVG(), "<svg"),
+            'png' =>  "<img src='data:image/png;base64,".base64_encode($diagramObject->callCurl($diagramObject->getPNGDiagramUrl()))."'>",
             'markup' => $diagramObject->getMarkup(),
             'id' => sha1($diagramObject->getSVGDiagramUrl()),
             'include_links' => $this->getConf('DefaultShowLinks'),
@@ -79,7 +80,8 @@ class syntax_plugin_plantumlparser_injector extends DokuWiki_Syntax_Plugin {
         $renderer->doc .= "<div id='plant-uml-diagram-".$data['id']."'>";
         if(strlen($data['svg']) > 0) {
 			if(is_a($renderer,'renderer_plugin_dw2pdf') && (preg_match("/(@startlatex|@startmath|<math|<latex)/", $data['markup']))){
-				$renderer->doc .= "<img src='".$data['url']['png']."'>";
+				// $renderer->doc .= "<img src='".$data['url']['png']."'>";
+                                $renderer->doc .= $data['png']; 
 			}
 			else {
 				$renderer->doc .= $data['svg'];


### PR DESCRIPTION
adressing #20 

replaced DokuHTTPClient())->get against php-curl due to timing issues; if response from remote server lasts too long, DokuHTTPClient->get continues without a sensible response (usually the response is empty).
This means that a pdf-export using the dw2pdf-plugin doesn't contain any plantuml data and therefore returns plantuml definition text.

added  workaround for @startlatex: 
i added png in $data-Object, so that png is availabel as needed when rendering @startlatex