### PR TITLE
Fixes a deprecation issue caused by DokuHTTPClient usage

### DIFF
--- a/syntax/PlantUmlDiagram.php
+++ b/syntax/PlantUmlDiagram.php
@@ -1,4 +1,7 @@
 <?php
+
+use dokuwiki\HTTP\DokuHTTPClient;
+
 if (!class_exists('PlantUmlDiagram')) {
     class PlantUmlDiagram {
         private $markup;


### PR DESCRIPTION
Using this plugin causes a deprecation-log entry in Dokuwiki:

```
DokuHTTPClient::__construct() is deprecated. It was called from PlantUmlDiagram::getSVG() in /[…]/PlantUmlDiagram.php:25 dokuwiki\HTTP\DokuHTTPClient should be used instead!
```

This commit solves the issue.